### PR TITLE
Use default timeout when none provided

### DIFF
--- a/lambda-pure.zsh
+++ b/lambda-pure.zsh
@@ -332,7 +332,7 @@ prompt_pure_async_callback() {
             local exec_time=$4
         else
             local output=
-            local exec_tim=$3
+            local exec_time=$3
         fi
 
 	case "${job}" in
@@ -343,7 +343,7 @@ prompt_pure_async_callback() {
 			# When prompt_pure_git_last_dirty_check_timestamp is set, the git info is displayed in a different color.
 			# To distinguish between a "fresh" and a "cached" result, the preprompt is rendered before setting this
 			# variable. Thus, only upon next rendering of the preprompt will the result appear in a different color.
-			(( $exec_time > 2 )) && prompt_pure_git_last_dirty_check_timestamp=$EPOCHSECONDS
+			(( ${exec_time:=5} > 2 )) && prompt_pure_git_last_dirty_check_timestamp=$EPOCHSECONDS
 			;;
 		prompt_pure_async_git_fetch)
 			prompt_pure_check_git_arrows


### PR DESCRIPTION
Hi there, nice theme!

I was getting a syntax error that there was no value on the left-hand side of the `> 2` expression, and in my cursory search I found a typo in the variable declaration. However, fixing the name did not remove the runtime error

So I added a default value to the variable use that corresponds to the 5-second default timeout mentioned in the documentation.

I don't know the root-cause of why `$3` is empty in the `else`-block, but this fix makes the experience a lot smoother on my system.